### PR TITLE
Fix .gitignore typo in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,4 +88,4 @@ To play your animations simply click on the play button in the top right corner.
 - You might have to click on the star icon in the top left corner in the WLED GUI to enable WLED to receive live UDP data
 
 # Important notes
-- *!!! The entire electron 'node_module' folder is not included in the source file due to large file sizes [.gitnore](https://github.com/RolandDaum/WLED-FAP/blob/master/.gitignore) !!!*
+- *!!! The entire electron 'node_module' folder is not included in the source file due to large file sizes [.gitignore](https://github.com/RolandDaum/WLED-FAP/blob/master/.gitignore) !!!*


### PR DESCRIPTION
Found and fixed a typo in [`README.md`](https://github.com/RolandDaum/WLED-FAP/blob/1a6318e4da3d18af591b888c669e3c2a6f3e17d4/docs/README.md) where `.gitignore` was misspelled as `.gitnore`.